### PR TITLE
Remove explicit uninstall of jupyterlab-requirements

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -8,8 +8,6 @@ set -eo pipefail
 
 /opt/app-root/builder/assemble
 
-pip3 uninstall -y jupyterlab-requirements
-
 # Activate ipywidgets extension.
 
 jupyter nbextension enable --py widgetsnbextension --sys-prefix


### PR DESCRIPTION
This is no longer necessary with a changed base image (in .aicoe-ci.yaml
on the master branch)

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2161
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
